### PR TITLE
Use correct execution state for AArch64/ILP32

### DIFF
--- a/elftools.cpp
+++ b/elftools.cpp
@@ -704,6 +704,12 @@ ElfFormat* ElfFormat::GetElfFormat(ElfClass::Type elfClass, uint8_t* start, uint
         *state = (A53ExecState::Type)A53ExecState::AARCH64;
         return new ElfFormat64(start);
     }
+    /* ELF32 may contain either ARMv7/AArch32 or AArch64 using the ILP32 data model */
+    else if (((Elf32_Ehdr*)start)->e_machine != 0x28)
+    {
+        *state = (A53ExecState::Type)A53ExecState::AARCH64;
+        return new ElfFormat32(start);
+    }
     else 
     {
         *state = (A53ExecState::Type)A53ExecState::AARCH32;


### PR DESCRIPTION
Check for non-ARM machine code when setting execution state since ELF32 can contain both ARMv7/AArch32 code as well as AArch64 code using the ILP32 data model.

Closes #7