### PR TITLE
Fix clang errors and warnings

### DIFF
--- a/authentication.h
+++ b/authentication.h
@@ -273,7 +273,6 @@ public:
     virtual void CopyPartitionSignature(BootImage& bi, std::list<Section*> sections, uint8_t* signatureBlock, Section* acSection) {};
     virtual void RearrangeEndianess(uint8_t *array, uint32_t size) {};
     virtual void AddAuthCertSizeToTotalFSBLSize(PartitionHeader* header) {};
-    virtual void CopySPKSignature(uint8_t* ptr) {};
     virtual void SetKeyLength(Authentication::Type type) {};
 
     void CreateSPKSignature(void);

--- a/authkeys-versal.cpp
+++ b/authkeys-versal.cpp
@@ -72,7 +72,12 @@ VersalKey::VersalKey(const Key& otherKey)
         eckey = EC_KEY_new_by_curve_name(NID_secp521r1);
     }
 
+#if REMOVED__PLEASE_CHECK_AND_REMOVE
+    // @todo this memory copy is broken in a number of ways and should be handled
+    // in the base constructor; this is left here for Xilinx to consider and sort
+    // out
     memcpy(this, &otherKey, sizeof(Key));
+#endif
 }
 
 /******************************************************************************/

--- a/authkeys.cpp
+++ b/authkeys.cpp
@@ -61,7 +61,7 @@ Key::Key(const Key& otherKey)
     E = new uint8_t [WORD_SIZE_IN_BYTES];
     P = new uint8_t [keySize/2];
     Q = new uint8_t [keySize/2];
-    memcpy(this,&otherKey,sizeof(Key)); 
+    *this = otherKey;
 }
 
 /******************************************************************************/
@@ -100,6 +100,19 @@ Key::~Key()
 }
 
 /******************************************************************************/
+Key& Key::operator=(const Key& otherKey)
+{
+    if (keySize == otherKey.keySize) {
+        memcpy(N, otherKey.N, keySize);
+        memcpy(N_ext, otherKey.N_ext, keySize);
+        memcpy(E, otherKey.E, WORD_SIZE_IN_BYTES);
+        memcpy(P, otherKey.P, keySize/2);
+        memcpy(Q, otherKey.Q, keySize/2);
+        memcpy(D, otherKey.D, keySize);
+    }
+    return *this;
+}
+
 void Key::ParsePublic(const std::string& filename)
 {
     Parse(filename,false); 

--- a/authkeys.h
+++ b/authkeys.h
@@ -117,6 +117,8 @@ public:
     void SetKeyName(std::string);
     static void GenerateRsaKeys(KeyGenerationStruct*);
 
+    Key& operator=(const Key& otherKey);
+
     bool Loaded;
     bool isSecret;
     uint8_t *N;         // modulus (2048 bits)

--- a/bifoptions.cpp
+++ b/bifoptions.cpp
@@ -750,7 +750,7 @@ void BifOptions::ParseUserKeyFile(std::string inputFileName)
         word.pop_back();
         if (word == "user_key")
         {
-            if (c > 7 && c < 0)
+            if (c > 7 || c < 0)
             {
                 LOG_ERROR("The AES user keys available are from 0 to 7. user_key%d is not supported", c);
             }

--- a/bootgenexception.h
+++ b/bootgenexception.h
@@ -50,13 +50,11 @@ public:
     BootGenExceptionClass(const char* filename0, int line0, const std::string& msg0 ) 
         : msg(msg0)
         , filename(filename0)
-        , line(line0) 
     {
     }
     
     BootGenExceptionClass(const char* filename0, int line0, const char* format, ...) 
         : filename(filename0)
-        , line(line0) 
     {
         va_list ap;
         va_start(ap, format);
@@ -76,6 +74,5 @@ public:
 private:
     std::string msg;
     std::string filename;
-    int line;
 };
 #endif

--- a/encryption-zynq.cpp
+++ b/encryption-zynq.cpp
@@ -897,7 +897,7 @@ void ZynqEncryptionContext::ReadEncryptionKeyFile(const std::string& inputFileNa
             break;
         }
 
-        char c;
+        char c = '\0';
         if (word == "Key")
         {
             // First Word is "Key"

--- a/partitionheadertable-zynqmp.cpp
+++ b/partitionheadertable-zynqmp.cpp
@@ -158,7 +158,7 @@ void ZynqMpPartitionHeader::SetTotalPartitionLength(uint32_t len)
 }
 
 /******************************************************************************/
-void ZynqMpPartitionHeader::SetNextPartitionHeaderOffset(void)
+void ZynqMpPartitionHeader::SetNextPartitionHeaderOffset(uint32_t )
 {
     static PartitionHeader* prev_part_hdr = NULL;
     if (prev_part_hdr != NULL)

--- a/partitionheadertable-zynqmp.h
+++ b/partitionheadertable-zynqmp.h
@@ -101,7 +101,7 @@ public:
     void ReadHeader(std::ifstream& ifs);
     void ReadData(std::ifstream& ifs);
     void RealignSectionDataPtr(void);
-    
+
     void SetEncryptedPartitionLength(uint32_t len);
     void SetUnencryptedPartitionLength(uint32_t len);
     void SetTotalPartitionLength(uint32_t len);
@@ -115,9 +115,9 @@ public:
     void SetAuthCertificateOffset(void);
     void SetPartitionNumber(uint32_t partNum);
     void SetChecksum(void);
-    void SetNextPartitionHeaderOffset(void);
+    void SetNextPartitionHeaderOffset(uint32_t addr);
     void SetBitLoadAddress(bool load, uint32_t val);
-    
+
     bool IsBootloader(void) { return isBootloader; }
     uint8_t GetDestinationDevice(void);
     uint8_t GetEncryptFlag(void);

--- a/partitionheadertable.cpp
+++ b/partitionheadertable.cpp
@@ -229,7 +229,7 @@ void PartitionHeaderTable::Link(BootImage &bi)
     for(std::list<PartitionHeader*>::iterator partHdr = bi.partitionHeaderList.begin(); partHdr != bi.partitionHeaderList.end(); partHdr++) 
     {
         (*partHdr)->Link(bi, NULL);
-        (*partHdr)->SetNextPartitionHeaderOffset();
+        (*partHdr)->SetNextPartitionHeaderOffset(0);
     }
 
     if (bi.bifOptions->GetHeaderAC() && ! bi.options.GetLegacyFlag())

--- a/partitionheadertable.h
+++ b/partitionheadertable.h
@@ -85,7 +85,7 @@ public:
     virtual void SetPartitionNumber(uint32_t partNum) {}
     virtual void SetChecksum(void) {}
     virtual void SetReserved(void) {}
-    virtual void SetNextPartitionHeaderOffset(void) {}
+    virtual void SetNextPartitionHeaderOffset(uint32_t addr) {}
     virtual void SetBitLoadAddress(bool load, uint32_t val) {}
     virtual void SetPartitionSize(Binary::Length_t) {}
 


### PR DESCRIPTION
The patch contains a number of fixes based on errors and warnings from `clang`.

Some of the fixes in key look important to me.