### PR TITLE
Fix build on machines with modern flex

### DIFF
--- a/FlexLexer.h
+++ b/FlexLexer.h
@@ -33,15 +33,15 @@
 //
 // If you want to create multiple lexer classes, you use the -P flag
 // to rename each yyFlexLexer to some other xxFlexLexer.  You then
-// include <FlexLexer.h> in your other sources once per lexer class:
+// include "FlexLexer.h" in your other sources once per lexer class:
 //
 //	#undef yyFlexLexer
 //	#define yyFlexLexer xxFlexLexer
-//	#include <FlexLexer.h>
+//	#include "FlexLexer.h"
 //
 //	#undef yyFlexLexer
 //	#define yyFlexLexer zzFlexLexer
-//	#include <FlexLexer.h>
+//	#include "FlexLexer.h"
 //	...
 
 #ifndef __FLEX_LEXER_H

--- a/bif.yy.cpp
+++ b/bif.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()

--- a/bifscanner.h
+++ b/bifscanner.h
@@ -28,7 +28,7 @@
 #if ! defined(yyFlexLexerOnce)
 #undef yyFlexLexer
 #define yyFlexLexer bifFlexLexer
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 #endif
 
 // Override the interface for yylex since we namespaced it

--- a/cmdoptions.yy.cpp
+++ b/cmdoptions.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()

--- a/cmdoptionsscanner.h
+++ b/cmdoptionsscanner.h
@@ -29,7 +29,7 @@
 
 #undef yyFlexLexer
 #define yyFlexLexer reginitFlexLexer
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 #endif
 
 // Override the interface for yylex since we namespaced it

--- a/reginit.yy.cpp
+++ b/reginit.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()

--- a/reginitscanner.h
+++ b/reginitscanner.h
@@ -29,7 +29,7 @@
 
 #undef yyFlexLexer
 #define yyFlexLexer reginitFlexLexer
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 #endif
 
 // Override the interface for yylex since we namespaced it


### PR DESCRIPTION
Bootgen embeds an old version of flex, but uses the system include syntax
(#include <>) to reference it, causing conflicts on systems with the
development headers for a modern flex version installed, leading to build
issues like:

../bisonflex/bif.yy.cpp: In member function 'virtual int BIF::FlexScanner::yylex()':
../bisonflex/bif.yy.cpp:1608:18: error: no match for 'operator=' (operand types are 'std::istream' {aka 'std::basic_istream<char>'} and 'std::istream*' {aka 'std::basic_istream<char>*'})

Fix it by using normal local #include statements by:

sed -i 's/<FlexLexer.h>/"FlexLexer.h"/g' *

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>