### PR TITLE
Refix builds on machines with modern flex versions

### DIFF
--- a/cmdoptions.yy.cpp
+++ b/cmdoptions.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()

--- a/reginit.yy.cpp
+++ b/reginit.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()


### PR DESCRIPTION
Bootgen embeds an old version of flex, but uses the system include syntax (#include <>) to reference it, causing conflicts on systems with the development headers for a modern flex version installed, leading to build issues like:

../bisonflex/cmdoptions.yy.cpp: In member function 'virtual int CO::FlexScanner::yylex()':
../bisonflex/cmdoptions.yy.cpp:1362:18: error: no match for 'operator=' (operand types are 'std::istream' {aka 'std::basic_istream<char>'} and 'std::istream*' {aka 'std::basic_istream<char>*'})

http://autobuild.buildroot.net/results/293/2936d9b054269b7055e66ab5a7f7c1f7f4926d48/build-end.log

Fix it by using normal local #include statements by:

sed -i 's/<FlexLexer.h>/"FlexLexer.h"/g' *

Notice: This was already fixed on master with:
https://github.com/Xilinx/bootgen/pull/20

Notice: The patch was not applied, instead a different patch with the same content was applied to master:
https://github.com/Xilinx/bootgen/commit/af4f7083ea92931a07e47995eb2bc2a348c577ed

This patch was not applied to the xlnx_rel_v2023.1 branch, instead most of the content was included in:
https://github.com/Xilinx/bootgen/commit/bfba91b2c84160dc203ff09f0e930d82ed06a83a

But the cmdoptions.yy.cpp and reginit.yy.cpp hunks were accidently dropped: https://github.com/Xilinx/bootgen/commit/bfba91b2c84160dc203ff09f0e930d82ed06a83a#diff-e0287adb420dbecc112acdf7d4a1efba8ea6cbf06401e4e8679b8ffd22a091d8