### PR TITLE
Fix error output for 32 bit elf headers

### DIFF
--- a/FlexLexer.h
+++ b/FlexLexer.h
@@ -33,15 +33,15 @@
 //
 // If you want to create multiple lexer classes, you use the -P flag
 // to rename each yyFlexLexer to some other xxFlexLexer.  You then
-// include <FlexLexer.h> in your other sources once per lexer class:
+// include "FlexLexer.h" in your other sources once per lexer class:
 //
 //	#undef yyFlexLexer
 //	#define yyFlexLexer xxFlexLexer
-//	#include <FlexLexer.h>
+//	#include "FlexLexer.h"
 //
 //	#undef yyFlexLexer
 //	#define yyFlexLexer zzFlexLexer
-//	#include <FlexLexer.h>
+//	#include "FlexLexer.h"
 //	...
 
 #ifndef __FLEX_LEXER_H
@@ -204,5 +204,3 @@ protected:
 
 #endif // yyFlexLexer || ! yyFlexLexerOnce
 
-
-// 67d7842dbbe25473c3c32b93c0da8047785f30d78e8a024de1b57352245f9689

--- a/bif.yy.cpp
+++ b/bif.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()

--- a/bifscanner.h
+++ b/bifscanner.h
@@ -28,7 +28,7 @@
 #if ! defined(yyFlexLexerOnce)
 #undef yyFlexLexer
 #define yyFlexLexer bifFlexLexer
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 #endif
 
 // Override the interface for yylex since we namespaced it

--- a/cmdoptions.yy.cpp
+++ b/cmdoptions.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()

--- a/cmdoptionsscanner.h
+++ b/cmdoptionsscanner.h
@@ -29,7 +29,7 @@
 
 #undef yyFlexLexer
 #define yyFlexLexer reginitFlexLexer
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 #endif
 
 // Override the interface for yylex since we namespaced it

--- a/elftools.cpp
+++ b/elftools.cpp
@@ -129,7 +129,7 @@ ElfFormat32::ElfFormat32(uint8_t* start)
     /* Basic ELF checks */
     if(ELFHdrEntrySize() != sizeof(Elf32_Ehdr)) 
     {
-        LOG_DEBUG(DEBUG_STAMP, "ELF Header size wrong - %d, actual size - %d", ELFHdrEntrySize(), sizeof(Elf64_Ehdr));
+        LOG_DEBUG(DEBUG_STAMP, "ELF Header size wrong - %d, actual size - %d", ELFHdrEntrySize(), sizeof(Elf32_Ehdr));
         LOG_ERROR("ELF Parsing Error !!!\n           Wrong Header Size");
     }
 

--- a/encryption.cpp
+++ b/encryption.cpp
@@ -319,7 +319,7 @@ static uint32_t GetRandomValue(uint32_t	maxValue)
 
     do
     {
-        returnValue = (myrand() / (int)(((unsigned)RAND_MAX + 1) / maxValue));
+        returnValue = (rand() / (int)(((unsigned)RAND_MAX + 1) / maxValue));
     } while (returnValue > maxValue);
 
     return returnValue;

--- a/reginit.yy.cpp
+++ b/reginit.yy.cpp
@@ -379,7 +379,7 @@ typedef unsigned char YY_CHAR;
 
 #define yytext_ptr yytext
 
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 
 int yyFlexLexer::yywrap() { return 1; }
 int yyFlexLexer::yylex()

--- a/reginitscanner.h
+++ b/reginitscanner.h
@@ -29,7 +29,7 @@
 
 #undef yyFlexLexer
 #define yyFlexLexer reginitFlexLexer
-#include <FlexLexer.h>
+#include "FlexLexer.h"
 #endif
 
 // Override the interface for yylex since we namespaced it


### PR DESCRIPTION
The error puts out the header size for 64-bit elf files when parsing a 32-bit elf file.