### PR TITLE
Remove reference to "cdo-rts.h"

### DIFF
--- a/cdo-driver/cdo_driver.c
+++ b/cdo-driver/cdo_driver.c
@@ -24,7 +24,6 @@
  * */
 /***************************** Include Files *********************************/
 
-#include "cdo_rts.h"
 #include "cdo_driver.h"
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This header is not published, and doesn't seem to be necessary to compile the code anyway.