### PR TITLE
Read header information before reading partitions

### DIFF
--- a/readimage-zynqmp.cpp
+++ b/readimage-zynqmp.cpp
@@ -100,6 +100,7 @@ void ZynqMpReadImage::ReadBinaryFile(DumpOption::Type dump, std::string path)
     {
         LOG_ERROR("The option '-read/-dump' is not supported on mcs format file : %s", binFilename.c_str());
     }
+    ReadHeaderTableDetails();
     ReadPartitions();
 }
 /*******************************************************************************/


### PR DESCRIPTION
Ran into this issue as well, just applying the change for convenience.

Fix for https://github.com/Xilinx/bootgen/issues/30