### PR TITLE
Added version request parameter

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,9 +5,9 @@
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
-* 
+*
 * http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,6 +61,21 @@ static void DisplayBanner()
     LOG_MSG("    ** Copyright 2022-%s Advanced Micro Devices, Inc. All Rights Reserved.\n", year ? year : "2023");
 }
 
+#define VERSION_ARG "--version"
+
+static bool HasVersionArg(int argc, const char *argv[])
+{
+    for (int i = 0; i < argc; i++)
+    {
+        if (strncmp(argv[i], VERSION_ARG, sizeof(VERSION_ARG)) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /******************************************************************************/
 class BootGenApp
 {
@@ -74,7 +89,7 @@ public:
         std::string bifFile = options.GetBifFilename();
         LOG_TRACE("BIF File: %s", bifFile.c_str());
 
-        if (bifFile.length() > 0) 
+        if (bifFile.length() > 0)
         {
             BIF_File bif(bifFile);
             bif.Process(options);
@@ -86,24 +101,29 @@ public:
 /******************************************************************************/
 int main(int argc, const char* argv[])
 {
-    try 
+    try
     {
         BootGenApp app;
         DisplayBanner();
-        app.Run(argc,argv);
+
+        if (!HasVersionArg(argc, argv))
+        {
+            app.Run(argc, argv);
+        }
+
         return 0;
     }
-    catch(std::exception& ex) 
+    catch(std::exception& ex)
     {
         std::cerr << "[ERROR]  : " << ex.what() << std::endl;
         return 1;
     }
-    catch(const char* msg) 
+    catch(const char* msg)
     {
         std::cerr << "FATAL: Internal Assertion: " << msg << std::endl;
         return 2;
     }
-    catch(...) 
+    catch(...)
     {
         std::cerr << "FATAL: Unknown Exception caught."<< std::endl;
         return 3;


### PR DESCRIPTION
As part of our build we want to list the version of bootgen being used, currently this is clunky since it requires us to give a bogus argument to get bootgen to run, and causes it to exit with an error code.

Added `--version` flag to just dump the banner and exit with status code 0.