### PR TITLE
Remove print statement (pollutes logging)

### DIFF
--- a/cdo-driver/cdo_driver.c
+++ b/cdo-driver/cdo_driver.c
@@ -145,7 +145,6 @@ void startCDOFileStream(const char* cdoFileName)
         printf("File could not be opened, fopen Error: %s\n", strerror(errno));
         exit(EXIT_FAILURE);
     }
-    printf("Generating: %s\n", cdoFileName);
 }
 
 void endCurrentCDOFileStream()


### PR DESCRIPTION
This logging appears in a compiler (iree, via mlir-aie) which indirectly uses bootgen, we'd prefer if this logging was not present by default 