### PR TITLE
verifyimage: Fix segmentation fault that occurs during verifyimage.

### DIFF
--- a/cdo-driver/cdo_driver.c
+++ b/cdo-driver/cdo_driver.c
@@ -145,7 +145,6 @@ void startCDOFileStream(const char* cdoFileName)
         printf("File could not be opened, fopen Error: %s\n", strerror(errno));
         exit(EXIT_FAILURE);
     }
-    printf("Generating: %s\n", cdoFileName);
 }
 
 void endCurrentCDOFileStream()

--- a/verifyimage-versal.cpp
+++ b/verifyimage-versal.cpp
@@ -34,7 +34,7 @@
 /*******************************************************************************/
 void VersalReadImage::VerifyAuthentication(bool verifyImageOption)
 {
-    ReadBinaryFile();
+    ReadHeaderTableDetails();
 
     if (iHT->headerAuthCertificateWordOffset != 0)
     {

--- a/verifyimage-zynqmp.cpp
+++ b/verifyimage-zynqmp.cpp
@@ -50,7 +50,7 @@ static void RearrangeEndianess(uint8_t *array, uint32_t size)
 /*******************************************************************************/
 void ZynqMpReadImage::VerifyAuthentication(bool verifyImageOption)
 {
-    ReadBinaryFile();
+    ReadHeaderTableDetails();
 
     if (iHT->headerAuthCertificateWordOffset != 0)
     {


### PR DESCRIPTION
In commit d02322b, the behavior of ReadBinaryFile was changed such that it no longer populated iHT. This caused VerifyAuthentication to access a null iHT value resulting a segementation fault.

This fix changes VerifyAuthentication to call ReadHeaderTableDetails instead, where the old functionality of ReadBinaryFile now lives.