### PR TITLE
Fix bad 'switch' statement usage; add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+bootgen

--- a/cdo-driver/cdo_driver.c
+++ b/cdo-driver/cdo_driver.c
@@ -145,7 +145,6 @@ void startCDOFileStream(const char* cdoFileName)
         printf("File could not be opened, fopen Error: %s\n", strerror(errno));
         exit(EXIT_FAILURE);
     }
-    printf("Generating: %s\n", cdoFileName);
 }
 
 void endCurrentCDOFileStream()

--- a/readimage-versal.cpp
+++ b/readimage-versal.cpp
@@ -1205,11 +1205,12 @@ std::string VersalReadImage::GetPartitionCore(uint32_t value)
         case 2:
             if (versalNetSeries) val = "a78-1";
             else val = "a72-1";         break;
-        if (versalNetSeries)
-        {
-            case 3: val = "a78-2";      break;
-            case 4: val = "a78-3";      break;
-        }
+        case 3:
+            if (versalNetSeries) val = "a78-2";
+            else val = "invalid";       break;
+        case 4:
+            if (versalNetSeries) val = "a78-3";
+            else val = "invalid";       break;
         case 5: val = "r5-0";           break;
         case 6: val = "r5-1";           break;
         case 7: val = "r5-lockstep";    break;


### PR DESCRIPTION
- The 'if' statement surrounding the 'case' doesn't make any sense. The compiler allows it for some reason, but the cases are always compiled in - no runtime checking of `versalNetSeries` happens.
- Also add a .gitignore (#25)