### PR TITLE
Bug fixes for v2025.2

### DIFF
--- a/common/include/xil-bignum.h
+++ b/common/include/xil-bignum.h
@@ -26,6 +26,22 @@ struct bignum_st {
 };
 
 /* Used for montgomery multiplication */
+/*
+ * The layout of this structure was changed in openSSL commit 3f540b6d.
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x30600000L
+struct bn_mont_ctx_st {
+    BIGNUM RR;                  /* used to convert to montgomery form */
+    BIGNUM N;                   /* The modulus */
+    BIGNUM Ni;                  /* R*(1/R mod N) - N*Ni = 1 (Ni is only
+                                 * stored for bignum algorithm) */
+    BN_ULONG n0[2];             /* least significant word(s) of Ni; (type
+                                 * changed with 0.9.9, was "BN_ULONG n0;"
+                                 * before) */
+    int ri;                     /* number of bits in R */
+    int flags;
+};
+#else
 struct bn_mont_ctx_st {
     int ri;                     /* number of bits in R */
     BIGNUM RR;                  /* used to convert to montgomery form */
@@ -37,5 +53,6 @@ struct bn_mont_ctx_st {
                                  * before) */
     int flags;
 };
+#endif
 
 #endif

--- a/common/src/authkeys.cpp
+++ b/common/src/authkeys.cpp
@@ -170,6 +170,7 @@ void Key::Parse(const std::string& filename, bool isSecret0)
             LOG_ERROR("Unsupported key file - %s\n           Supported key formats: AMD Format & OpenSSL format", basefile.c_str());
         }
         fclose(f);
+        f = NULL;
 
         if(errCode != 0)
         {
@@ -195,7 +196,10 @@ void Key::Parse(const std::string& filename, bool isSecret0)
     }
     catch(...) 
     {
-        fclose(f);
+        if (f!=NULL)
+        {
+            fclose(f);
+        }
         throw;
     }
 }

--- a/lms-hash-sigs/hss_param.c
+++ b/lms-hash-sigs/hss_param.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdio.h>
 #include "hss.h"
 #include "hss_internal.h"
 #include "endian.h"


### PR DESCRIPTION
This pull request contains 3 bug fixes for the following issues:

* v2025.2 does not compile (at least on my Arch Linux) because of a missing include
* a commit in openSSL changed a structure that is also used in bootgen, leading to misinterpreted data
* the previous issue triggers a "double free" error in the current code