### PR TITLE
cdo: Fix incompatible-pointer-types in cdoseq_load_cdo_from_buffer

### DIFF
--- a/utils/src/cdo-load.c
+++ b/utils/src/cdo-load.c
@@ -137,7 +137,7 @@ CdoSequence * cdoseq_load_cdo_from_buffer(char * data, size_t size) {
     if (data == NULL) goto done;
     raw = cdoraw_decode(data, size);
     if (raw != NULL) {
-        data = raw->data;
+        data = (char *)raw->data;
         size = raw->size;
     }
     if (is_cdo_data(data, size)) {


### PR DESCRIPTION
GCC 14 promotes -Wincompatible-pointer-types to a hard error, so the build fails with:

```
  utils/src/cdo-load.c:140:14: error: assignment to 'char *' from incompatible pointer type 'uint32_t *' {aka 'unsigned int *'} [-Wincompatible-pointer-types]
    140 |         data = raw->data;
        |              ^
  make: *** [Makefile:81: build/obj/cdo-load.o] Error 1
```

The function parameter data is char *, but raw->data (struct CdoRawInfo) is uint32_t *. The sibling function cdoseq_load_cdo avoids this because its local data is void *, which accepts any pointer without a cast.

Add an explicit (char *) cast.