### PR TITLE
zynqmp: Fix decoding errors in DisplayBhAttributes

### DIFF
--- a/zynqmp/src/readimage-zynqmp.cpp
+++ b/zynqmp/src/readimage-zynqmp.cpp
@@ -484,11 +484,19 @@ void ZynqMpReadImage::DisplayBhAttributes(uint32_t value)
 {
     std::string val, val1;
 
-    switch ((value >> AUTH_ONLY_BIT_SHIFT) & OPT_KEY_BIT_MASK)
+    switch ((value >> OPT_KEY_BIT_SHIFT) & OPT_KEY_BIT_MASK)
     {
     case 3: val = "[true]";         break;
     default: val = "[false]";       break;
     }
+    val1 = val;
+
+    switch ((value >> AUTH_HASH_BIT_SHIFT) & AUTH_HASH_BIT_MASK)
+    {
+    case 3: val = "[sha-2]";        break;
+    default: val = "[sha-3]";       break;
+    }
+    DisplayAttributes("opt_key ", val1, "auth_hash ", val);
 
     switch ((value >> AUTH_ONLY_BIT_SHIFT) & AUTH_ONLY_BIT_MASK)
     {
@@ -513,26 +521,28 @@ void ZynqMpReadImage::DisplayBhAttributes(uint32_t value)
 
     switch ((value >> CORE_BIT_SHIFT) & CORE_BIT_MASK)
     {
-    case 3: val = "[enabled]";      break;
-    default: val = "[disabled]";    break;
+    case 0: val = "[r5-single]";    break;
+    case 1: val = "[a53-x32]";      break;
+    case 2: val = "[a53-x64]";      break;
+    case 3: val = "[r5-dual]";      break;
     }
     DisplayAttributes("checksum ", val1, "core ", val);
 
-    switch ((value >> AUTH_HASH_BIT_SHIFT) & AUTH_HASH_BIT_MASK)
+    switch ((value >> BH_PUF_MODE_BIT_SHIFT) & BH_PUF_MODE_BIT_MASK)
     {
-    case 2: val = "[puf-12k]";      break;
+    case 0: val = "[puf-12k]";      break;
     case 3: val = "[puf-4k]";       break;
     default: val = "[invalid]";     break;
     }
+    val1 = val;
 
     switch ((value >> BH_RSA_BIT_SHIFT) & BH_RSA_BIT_MASK)
     {
     case 3: val = "[enabled]";      break;
     default: val = "[disabled]";    break;
     }
-    val1 = val;
 
-    DisplayAttributes("bh_auth ", val1, "puf_mode ", val);
+    DisplayAttributes("puf_mode ", val1, "bh_auth ", val);
 }
 
 /*******************************************************************************/


### PR DESCRIPTION
DisplayBhAttributes decodes the fsblAttributes word (boot header offset 0x44, UG1085 Table 11-5 "Image Attributes") for display. Four fields were decoded incorrectly; none affect image generation but proper decoding may help debug secure boot failures.

opt_key ([3:2]) was extracted using AUTH_ONLY_BIT_SHIFT instead of OPT_KEY_BIT_SHIFT, and its value was then overwritten before the DisplayAttributes call, so it was never shown.

auth_hash ([13:12], "SHA2 select") was not shown at all.

The core/CPU select field ([11:10]) was treated as a boolean, producing [enabled] or [disabled]. It is a four-value field per the Core enum and UG1085 v2.5 Table 11-5.

puf_mode was extracted from AUTH_HASH_BIT_SHIFT ([13:12]) instead of BH_PUF_MODE_BIT_SHIFT ([17:16]), and used case constant 2 where the PufMode enum defines 0 as puf-12k. The value was also overwritten by the bh_auth switch before display.

All attribute decodings now consistently match the flow of "set val, copy to val1, set val, display attributes" which already existed for some attributes.