### PR TITLE
auth: Fix GetPresign() overwriting caller buffer

### DIFF
--- a/common/src/authentication.cpp
+++ b/common/src/authentication.cpp
@@ -294,7 +294,6 @@ void AuthenticationContext::GetPresign(const std::string& presignFilename, uint8
     }
 
     LOG_TRACE("Reading presign file - %s", filename.c_str());
-    signature = new uint8_t[signatureLength];
     FILE* filePtr;
     filePtr = fopen(filename.c_str(),"rb");
     if (filePtr) 


### PR DESCRIPTION
GetPresign() takes the output signature buffer as an out-parameter, but reassigned that local pointer to a freshly allocated buffer before reading the presign file into it. This caused the caller's buffer to never be filled in with the expected signature data.  This function is the shared path for SPK, BH, and partition presign files, so all three signature fields in the Authentication Certificate would come out zero in offline/presigned-signing workflows despite bootgen logging success.

The regression was introduced by commit
efa41c591195a0ffa86528e391bcd01ff76aded0, "2026.1 feature update  (#53)".