### PR TITLE
Fix logical OR tautology in Zynq/ZynqMP architecture check

### DIFF
--- a/bisonflex/bif.tab.cpp
+++ b/bisonflex/bif.tab.cpp
@@ -812,7 +812,7 @@ namespace BIF {
   case 83:
 /* Line 670 of lalr1.cc  */
 #line 384 "parser/bif.y"
-    { if(options.GetArchType() != Arch::ZYNQ || options.GetArchType() != Arch::ZYNQMP)
+    { if(options.GetArchType() != Arch::ZYNQ && options.GetArchType() != Arch::ZYNQMP)
                                                                                     LOG_WARNING("BIF attribute error !!! [keysrc_encryption] not supported for the specified architecture.\n\t   Refer 'bootgen -bif_help' for more details");
                                                                                   currentBifOptions->SetEncryptionKeySource((yysemantic_stack_[(4) - (4)].encrkeysrc_t)); options.SetEncryptedKeySource((yysemantic_stack_[(4) - (4)].encrkeysrc_t)); }
     break;

--- a/parser/bif.y
+++ b/parser/bif.y
@@ -381,7 +381,7 @@ partition_content       :   /* empty */
                         |   partition_content new_file_spec
                         ;
 
-other_spec              :   OBRACKET KEYSRC_ENCRYPTION EBRACKET key_src         { if(options.GetArchType() != Arch::ZYNQ || options.GetArchType() != Arch::ZYNQMP)
+other_spec              :   OBRACKET KEYSRC_ENCRYPTION EBRACKET key_src         { if(options.GetArchType() != Arch::ZYNQ && options.GetArchType() != Arch::ZYNQMP)
                                                                                     LOG_WARNING("BIF attribute error !!! [keysrc_encryption] not supported for the specified architecture.\n\t   Refer 'bootgen -bif_help' for more details");
                                                                                   currentBifOptions->SetEncryptionKeySource($4); options.SetEncryptedKeySource($4); }
                         |   OBRACKET FSBL_CONFIG                                { if(options.GetArchType() == Arch::ZYNQ)


### PR DESCRIPTION
The condition `if(options.GetArchType() != Arch::ZYNQ || options.GetArchType() != Arch::ZYNQMP)` always evaluates to true.
This causes a spurious warning.
Fixed by replacing OR by AND.